### PR TITLE
Link the cabal file inside the cabal2nix build to resolve #5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release History
 
+## [?.?] - Unreleased
+
+  * Link the cabal file inside the cabal2nix build to resolve #5
+
 ## [2.0] - 2020-06-07
 
   * Automatically build the latest versions of `ghcide` and `ormolu`

--- a/nix/cabal2nix.nix
+++ b/nix/cabal2nix.nix
@@ -10,7 +10,6 @@
 #
 { pkgs, cabal, flags }:
 with pkgs.lib;
-
 let
   # The package name derived from the cabal file name:
   name = removeSuffix ".cabal" (baseNameOf (toString cabal));
@@ -18,13 +17,15 @@ let
   # All flags as a string:
   flagsStr = concatMapStringsSep " " (f: "-f${f}") flags;
 
-in pkgs.stdenvNoCC.mkDerivation {
-  name = "${name}.nix";
-  src = cabal;
-
+in
+pkgs.stdenvNoCC.mkDerivation {
+  name = "${name}-cabal2nix";
+  phases = [ "buildPhase" ];
   buildInputs = with pkgs; [ cabal2nix ];
 
   buildCommand = ''
-    cabal2nix ${flagsStr} $(dirname ${cabal}) > $out
+    mkdir -p $out
+    ln -s ${cabal} $out/${name}.cabal
+    cabal2nix ${flagsStr} $out > $out/default.nix
   '';
 }


### PR DESCRIPTION
cabal2nix needs to be given a directory containing a cabal
file (giving it a file instead of a directory changes what it does).

This change links the cabal file into the $out directory so cabal2nix
will only see the contents of the $out directory as opposed to looking
at the entire Nix store.