### PR TITLE
Filter out files/directories that start with a dot (".")

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -16,8 +16,10 @@ let
   haskellSourceFilter = name: type:
     let baseName = baseNameOf (toString name);
     in
-      !(baseName == "dist" || baseName == "dist-newstyle" || baseName == "TAGS"
-        || hasPrefix ".ghc.environment" baseName);
+      !(baseName == "dist"
+        || baseName == "dist-newstyle"
+        || baseName == "TAGS"
+        || hasPrefix "." baseName);
 
 in
 rec {


### PR DESCRIPTION
This change keeps directories like `.stack-work' out of the Nix store.